### PR TITLE
feat: add search autocomplete plus split/delete_pages document operations

### DIFF
--- a/docs/concepts/documents.md
+++ b/docs/concepts/documents.md
@@ -588,6 +588,33 @@ await paperless.documents.bulk_edit.edit_pdf(
 )
 ```
 
+`split()` and `delete_pages()` are convenience wrappers around `edit_pdf()` - both take a
+single document, like `edit_pdf()` itself:
+
+```python
+# two new documents: pages 1-2 and page 3
+await paperless.documents.bulk_edit.split(
+    42,
+    [[1, 2], [3]],
+    delete_originals=False,  # move the source document to trash afterwards
+)
+
+# drop pages 2 and 4, creating a new version of document 42
+await paperless.documents.bulk_edit.delete_pages(42, [2, 4])
+```
+
+Two things worth knowing:
+
+- The documents produced by `split()` inherit the source metadata **unchanged** - there is
+  no `(split 1)`, `(split 2)`, … title suffix. Rename the results afterwards if you need it.
+- The API keeps the pages it is handed rather than removing them, so `delete_pages()` needs
+  the total page count and looks it up with one extra request. Pass `page_count=` when you
+  already have the document, when its record carries no page count (not a PDF, or not
+  processed yet), or when `source_mode` selects a file with a different number of pages.
+
+Both raise `ValueError` for input that cannot produce a valid PDF - no page groups, an empty
+group, no pages to remove, page numbers outside the document, or removing every page.
+
 `remove_password()` decrypts password-protected PDFs:
 
 ```python
@@ -600,12 +627,12 @@ await paperless.documents.bulk_edit.remove_password(
 
 ### Choosing the source file
 
-`rotate()`, `merge()`, `edit_pdf()` and `remove_password()` all accept `source_mode`,
-which selects the file the operation reads from - `"latest_version"` (default) or
-`"original"`:
+`rotate()`, `merge()`, `edit_pdf()`, `split()`, `delete_pages()` and `remove_password()` all
+accept `source_mode`, which selects the file the operation reads from - `"latest_version"`
+(default) or `"explicit_selection"`:
 
 ```python
-await paperless.documents.bulk_edit.rotate([1, 2], 90, source_mode="original")
+await paperless.documents.bulk_edit.rotate([1, 2], 90, source_mode="explicit_selection")
 ```
 
 All bulk edit operations raise `BulkEditError` (a `ResponseError` subclass) when the API returns a non-OK result.

--- a/docs/concepts/documents.md
+++ b/docs/concepts/documents.md
@@ -611,9 +611,17 @@ Two things worth knowing:
   the total page count and looks it up with one extra request. Pass `page_count=` when you
   already have the document, when its record carries no page count (not a PDF, or not
   processed yet), or when `source_mode` selects a file with a different number of pages.
+- That count comes from an earlier request, so the pages to keep are a snapshot. If the
+  document gains a version in between, the wrong pages survive - a shorter file is rejected
+  by the server as out of bounds, but a longer one silently loses its extra pages. Passing
+  `page_count=` does not close that window; it only skips the lookup, moving the staleness to
+  your own read. The native, now-deprecated `delete_pages` bulk method avoided this by
+  removing pages by index server-side.
 
-Both raise `ValueError` for input that cannot produce a valid PDF - no page groups, an empty
-group, no pages to remove, page numbers outside the document, or removing every page.
+Both raise `BulkEditPagesError` for input that cannot produce a valid PDF - no page groups, an
+empty group, no pages to remove, page numbers outside the document, or removing every page.
+It subclasses both `DocumentError` and `ValueError`, and the checks run before any request is
+sent. See [Exceptions](../exceptions.md#bulkeditpageserror).
 
 `remove_password()` decrypts password-protected PDFs:
 

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -34,6 +34,7 @@ PaperlessError
 │   └── TaskNotFoundError
 └── DocumentError
     ├── AsnRequestError
+    ├── BulkEditPagesError
     └── SendEmailError
 ```
 
@@ -241,6 +242,12 @@ Base class for exceptions raised by document-specific service operations. Catch 
 #### `AsnRequestError`
 
 Raised when the request for the next available archive serial number fails unexpectedly.
+
+#### `BulkEditPagesError`
+
+Raised by `documents.bulk_edit.split()` and `.delete_pages()` when the page selection cannot produce a valid PDF: no page groups, an empty group, no pages to remove, page numbers outside the document, or removing every page. Also raised when the page count has to be looked up and the document record carries none - not a PDF, or not processed yet.
+
+This one has two bases - `DocumentError` **and** `ValueError` - so both `except PaperlessError` and `except ValueError` catch it. The checks run before any request is sent.
 
 #### `SendEmailError`
 

--- a/docs/migrating-v5-to-v6.md
+++ b/docs/migrating-v5-to-v6.md
@@ -662,6 +662,8 @@ await paperless.documents.bulk_edit.merge(
 
 # PDF page operations and password removal
 await paperless.documents.bulk_edit.edit_pdf(42, [{"page": 1, "rotate": 90}])
+await paperless.documents.bulk_edit.split(42, [[1, 2], [3]])
+await paperless.documents.bulk_edit.delete_pages(42, [2, 4])
 await paperless.documents.bulk_edit.remove_password([5, 6], password="secret")
 ```
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -36,7 +36,8 @@ Every Paperless-ngx entity is exposed through a **service** on the `PaperlessCli
     `bulk_edit_objects` exposes bulk `set_permissions` and `delete` for tags,
     correspondents, document types and storage paths. `documents.bulk_edit` exposes
     bulk operations (set metadata, tags, custom fields, permissions, delete, reprocess,
-    rotate, merge, edit PDF pages, remove PDF passwords) for documents. Neither service
+    rotate, merge, edit PDF pages, split, delete pages, remove PDF passwords) for
+    documents. Neither service
     follows the standard CRUD pattern above.
     See [Bulk Edit Objects](resources/bulk_edit_objects.md) and the
     [Documents concept page](concepts/documents.md#bulk-editing) for details.

--- a/docs/resources/search.md
+++ b/docs/resources/search.md
@@ -1,6 +1,6 @@
 # Search
 
-The `search` resource exposes the Paperless-ngx global search endpoint (`/api/search/`). It searches across documents, tags, correspondents, document types, and other resource types simultaneously and returns a scored, ranked result.
+The `search` resource exposes the Paperless-ngx global search endpoint (`/api/search/`). It searches across documents, tags, correspondents, document types, and other resource types simultaneously and returns a scored, ranked result. It also exposes the typeahead endpoint (`/api/search/autocomplete/`) via [`autocomplete()`](#autocomplete).
 
 ## Model
 
@@ -56,6 +56,19 @@ Pass `db_only=True` to skip the full-text index and search only the database fie
 ```python
 result = await paperless.search("contract", db_only=True)
 ```
+
+### Autocomplete
+
+`autocomplete()` hits `/api/search/autocomplete/` and returns a plain list of index terms - the typeahead helper behind the Paperless-ngx search bar, not resource objects:
+
+```python
+terms = await paperless.search.autocomplete("inv")
+# ['invoice', 'invoices', 'invoiced']
+
+terms = await paperless.search.autocomplete("inv", 3)
+```
+
+`limit` is omitted from the request when left at `None`, which leaves the server default (10) in place. An empty term or a `limit` below 1 is rejected by the server with HTTP 400, raising `UnexpectedStatusError`.
 
 ### Working with results
 

--- a/pypaperless/const.py
+++ b/pypaperless/const.py
@@ -86,6 +86,7 @@ class EndpointPath(StrEnum):
     SAVED_VIEWS_SINGLE = "/api/saved_views/{pk}/"
 
     SEARCH = "/api/search/"
+    SEARCH_AUTOCOMPLETE = "/api/search/autocomplete/"
 
     SHARE_LINKS = "/api/share_links/"
     SHARE_LINKS_SINGLE = "/api/share_links/{pk}/"

--- a/pypaperless/exceptions.py
+++ b/pypaperless/exceptions.py
@@ -182,3 +182,11 @@ class AsnRequestError(DocumentError):
 
 class SendEmailError(DocumentError):
     """Raised when sending email for a document fails."""
+
+
+class BulkEditPagesError(DocumentError, ValueError):
+    """Raised when a page selection for a PDF page operation cannot be applied.
+
+    Also a :class:`ValueError`, so callers may catch either that or
+    :class:`PaperlessError`.
+    """

--- a/pypaperless/models/bulk_edit.py
+++ b/pypaperless/models/bulk_edit.py
@@ -3,7 +3,7 @@
 from typing import Any, Literal, TypedDict
 
 type BulkEditObjectType = Literal["tags", "correspondents", "document_types", "storage_paths"]
-type SourceMode = Literal["latest_version", "original"]
+type SourceMode = Literal["latest_version", "explicit_selection"]
 type CustomFieldsInput = list[int] | dict[int, Any]
 
 

--- a/pypaperless/services/documents/bulk_edit.py
+++ b/pypaperless/services/documents/bulk_edit.py
@@ -18,6 +18,18 @@ class DocumentBulkEditService(PaperlessService):
         if data.get("result") != "OK":
             raise BulkEditError(str(data.get("result")))
 
+    async def _page_count(self, document: int) -> int:
+        """Read `page_count` off the document record; the kept-pages complement needs it."""
+        data = await self._runtime.transport.get(EndpointPath.DOCUMENTS_SINGLE.format(pk=document))
+        page_count: int | None = data.get("page_count")
+        if page_count is None:
+            msg = (
+                f"Document {document} reports no page count (not a PDF, or not processed yet) "
+                "— pass page_count explicitly."
+            )
+            raise ValueError(msg)
+        return page_count
+
     async def set_correspondent(
         self,
         documents: list[int],
@@ -281,7 +293,8 @@ class DocumentBulkEditService(PaperlessService):
         Args:
             documents:   List of document primary keys to rotate.
             degrees:     Rotation angle in degrees (e.g. ``90``, ``180``, ``270``).
-            source_mode: Whether to operate on ``"latest_version"`` or ``"original"``.
+            source_mode: Whether to operate on ``"latest_version"`` or
+                         ``"explicit_selection"``.
 
         Example::
 
@@ -316,7 +329,7 @@ class DocumentBulkEditService(PaperlessService):
             archive_fallback:     When ``True``, use the archived version when the
                                   original is unavailable.
             source_mode:          Whether to operate on ``"latest_version"`` or
-                                  ``"original"``.
+                                  ``"explicit_selection"``.
 
         Example::
 
@@ -363,7 +376,7 @@ class DocumentBulkEditService(PaperlessService):
             include_metadata: When ``True``, metadata is carried over to the
                               resulting document.
             source_mode:      Whether to operate on ``"latest_version"`` or
-                              ``"original"``.
+                              ``"explicit_selection"``.
 
         Example::
 
@@ -383,6 +396,107 @@ class DocumentBulkEditService(PaperlessService):
             "source_mode": source_mode,
         }
         await self._post(EndpointPath.DOCUMENTS_EDIT_PDF, json=payload)
+
+    async def split(
+        self,
+        document: int,
+        pages: list[list[int]],
+        *,
+        delete_originals: bool = False,
+        source_mode: SourceMode = "latest_version",
+    ) -> None:
+        """Split a document into several new documents, one per page group.
+
+        Note: the API only supports a **single** document per request.  This is a
+        convenience wrapper around :meth:`edit_pdf`, so the results inherit the
+        source metadata unchanged — there is no ``(split N)`` title suffix.
+
+        Args:
+            document:         Primary key of the document to split.
+            pages:            One list of 1-based page numbers per resulting
+                              document.  ``[[1, 2], [3]]`` yields two documents:
+                              pages 1-2 and page 3.  Pages listed in no group are
+                              dropped; the server validates the page numbers.
+            delete_originals: When ``True``, the source document is moved to
+                              trash once the new documents are consumed.
+            source_mode:      Whether to operate on ``"latest_version"`` or
+                              ``"explicit_selection"``.
+
+        Example::
+
+            await paperless.documents.bulk_edit.split(42, [[1, 2], [3]])
+
+        """
+        if not pages:
+            msg = "split() requires at least one page group."
+            raise ValueError(msg)
+        if any(not group for group in pages):
+            msg = "split() page groups must not be empty."
+            raise ValueError(msg)
+
+        operations: list[EditPdfOperation] = [
+            {"page": page, "doc": index} for index, group in enumerate(pages) for page in group
+        ]
+        await self.edit_pdf(
+            document,
+            operations,
+            delete_original=delete_originals,
+            source_mode=source_mode,
+        )
+
+    async def delete_pages(
+        self,
+        document: int,
+        pages: list[int],
+        *,
+        page_count: int | None = None,
+        source_mode: SourceMode = "latest_version",
+    ) -> None:
+        """Remove pages from a document, creating a new version of it.
+
+        Note: the API has no "remove" operation — :meth:`edit_pdf` keeps exactly
+        the pages it is handed — so the complement of *pages* is computed here,
+        which needs the total page count.
+
+        Args:
+            document:    Primary key of the document to edit.
+            pages:       1-based page numbers to remove.
+            page_count:  Total pages of the source file.  Looked up from the
+                         document record when ``None``.  Pass it to save that
+                         request, for documents whose record carries no page
+                         count, or when ``source_mode`` selects a file with a
+                         different number of pages than the document record.
+            source_mode: Whether to operate on ``"latest_version"`` or
+                         ``"explicit_selection"``.
+
+        Example::
+
+            await paperless.documents.bulk_edit.delete_pages(42, [2, 4])
+
+        """
+        if not pages:
+            msg = "delete_pages() requires at least one page to remove."
+            raise ValueError(msg)
+        if page_count is None:
+            page_count = await self._page_count(document)
+
+        out_of_range = sorted({page for page in pages if not 1 <= page <= page_count})
+        if out_of_range:
+            msg = f"Pages {out_of_range} are out of range for a {page_count} page document."
+            raise ValueError(msg)
+
+        remaining = sorted(set(range(1, page_count + 1)) - set(pages))
+        if not remaining:
+            msg = "delete_pages() must keep at least one page."
+            raise ValueError(msg)
+
+        operations: list[EditPdfOperation] = [{"page": page} for page in remaining]
+        await self.edit_pdf(
+            document,
+            operations,
+            update_document=True,
+            source_mode=source_mode,
+        )
 
     async def remove_password(
         self,
@@ -404,7 +518,7 @@ class DocumentBulkEditService(PaperlessService):
                               trash after decryption.
             include_metadata: When ``True``, metadata is carried over.
             source_mode:      Whether to operate on ``"latest_version"`` or
-                              ``"original"``.
+                              ``"explicit_selection"``.
 
         Example::
 

--- a/pypaperless/services/documents/bulk_edit.py
+++ b/pypaperless/services/documents/bulk_edit.py
@@ -1,7 +1,7 @@
 """Provide `DocumentBulkEdit` service."""
 
 from pypaperless.const import EndpointPath
-from pypaperless.exceptions import BulkEditError
+from pypaperless.exceptions import BulkEditError, BulkEditPagesError
 from pypaperless.models.bulk_edit import CustomFieldsInput, EditPdfOperation, SourceMode
 from pypaperless.models.mixins.securable import Permissions
 from pypaperless.services.base import PaperlessService
@@ -27,7 +27,7 @@ class DocumentBulkEditService(PaperlessService):
                 f"Document {document} reports no page count (not a PDF, or not processed yet) "
                 "— pass page_count explicitly."
             )
-            raise ValueError(msg)
+            raise BulkEditPagesError(msg)
         return page_count
 
     async def set_correspondent(
@@ -422,6 +422,9 @@ class DocumentBulkEditService(PaperlessService):
             source_mode:      Whether to operate on ``"latest_version"`` or
                               ``"explicit_selection"``.
 
+        Raises:
+            BulkEditPagesError: When *pages* is empty or contains an empty group.
+
         Example::
 
             await paperless.documents.bulk_edit.split(42, [[1, 2], [3]])
@@ -429,10 +432,10 @@ class DocumentBulkEditService(PaperlessService):
         """
         if not pages:
             msg = "split() requires at least one page group."
-            raise ValueError(msg)
+            raise BulkEditPagesError(msg)
         if any(not group for group in pages):
             msg = "split() page groups must not be empty."
-            raise ValueError(msg)
+            raise BulkEditPagesError(msg)
 
         operations: list[EditPdfOperation] = [
             {"page": page, "doc": index} for index, group in enumerate(pages) for page in group
@@ -458,6 +461,13 @@ class DocumentBulkEditService(PaperlessService):
         the pages it is handed — so the complement of *pages* is computed here,
         which needs the total page count.
 
+        Because that count comes from an earlier request, the pages to keep are
+        a snapshot: if the document gains a version between the lookup and the
+        edit, the wrong pages survive.  A shorter file is rejected by the server
+        as out of bounds, but a longer one silently loses its extra pages.
+        Passing *page_count* does not close that window — it only skips the
+        lookup, moving the staleness to the caller's own read.
+
         Args:
             document:    Primary key of the document to edit.
             pages:       1-based page numbers to remove.
@@ -469,6 +479,10 @@ class DocumentBulkEditService(PaperlessService):
             source_mode: Whether to operate on ``"latest_version"`` or
                          ``"explicit_selection"``.
 
+        Raises:
+            BulkEditPagesError: When *pages* is empty, falls outside the
+                document, or would remove every page.
+
         Example::
 
             await paperless.documents.bulk_edit.delete_pages(42, [2, 4])
@@ -476,19 +490,19 @@ class DocumentBulkEditService(PaperlessService):
         """
         if not pages:
             msg = "delete_pages() requires at least one page to remove."
-            raise ValueError(msg)
+            raise BulkEditPagesError(msg)
         if page_count is None:
             page_count = await self._page_count(document)
 
         out_of_range = sorted({page for page in pages if not 1 <= page <= page_count})
         if out_of_range:
             msg = f"Pages {out_of_range} are out of range for a {page_count} page document."
-            raise ValueError(msg)
+            raise BulkEditPagesError(msg)
 
         remaining = sorted(set(range(1, page_count + 1)) - set(pages))
         if not remaining:
             msg = "delete_pages() must keep at least one page."
-            raise ValueError(msg)
+            raise BulkEditPagesError(msg)
 
         operations: list[EditPdfOperation] = [{"page": page} for page in remaining]
         await self.edit_pdf(

--- a/pypaperless/services/search.py
+++ b/pypaperless/services/search.py
@@ -1,5 +1,7 @@
 """Provide `Search` service."""
 
+from typing import cast
+
 from pypaperless.builders import SearchQuery
 from pypaperless.const import EndpointPath, PaperlessResource
 from pypaperless.models.search import SearchResult
@@ -45,3 +47,31 @@ class SearchService(ResourceService):
             params["db_only"] = db_only
         res = await self._runtime.transport.get(self._api_path, params=params)
         return self._resource_cls.from_data(self._runtime, res)
+
+    async def autocomplete(self, term: str, limit: int | None = None) -> list[str]:
+        """Return full-text index terms completing a partial search term.
+
+        This is the typeahead helper behind the Paperless-ngx search bar — it
+        answers with bare strings from the search index, not resource objects.
+
+        Args:
+            term:  Prefix to complete.  An empty term is rejected by the server
+                   with HTTP 400, surfacing as
+                   :exc:`~pypaperless.exceptions.UnexpectedStatusError`.
+            limit: Maximum number of terms to return.  Defaults to ``None``,
+                   which omits the parameter and leaves the server default (10)
+                   in place.  Values below ``1`` are rejected by the server.
+
+        Example::
+
+            terms = await paperless.search.autocomplete("inv")
+            # ["invoice", "invoices", "invoiced"]
+
+            terms = await paperless.search.autocomplete("inv", limit=3)
+
+        """
+        params: dict[str, str | int] = {"term": term}
+        if limit is not None:
+            params["limit"] = limit
+        res = await self._runtime.transport.get(EndpointPath.SEARCH_AUTOCOMPLETE, params=params)
+        return cast("list[str]", res)

--- a/script/pngx_audit_coverage.py
+++ b/script/pngx_audit_coverage.py
@@ -422,6 +422,7 @@ KNOWN_UTILITY_PATHS: set[str] = {
     "/api/profile/generate_auth_token/",
     "/api/profile/social_account_providers/",
     "/api/profile/totp/",
+    "/api/search/autocomplete/",
     "/api/storage_paths/test/",
     "/api/tasks/acknowledge/",
     "/api/tasks/active/",
@@ -435,7 +436,6 @@ KNOWN_UTILITY_PATHS: set[str] = {
 INTENTIONALLY_SKIPPED_PATHS: set[str] = {
     "/api/logs/",  # server log streaming, not a resource
     "/api/logs/{id}/",  # server log streaming, not a resource
-    "/api/search/autocomplete/",  # UI helper, not a library concern
     "/api/ui_settings/",  # paperless-ngx front-end settings, not exposed
 }
 

--- a/script/pngx_smoketest.py
+++ b/script/pngx_smoketest.py
@@ -247,6 +247,12 @@ async def test_search(p: PaperlessClient) -> None:
         detail_fn=lambda r: f"total={r.total}, query={str(q)!r}",
     )
 
+    await check(
+        "search.autocomplete('inv')",
+        p.search.autocomplete("inv", 5),
+        detail_fn=lambda r: f"terms={r}",
+    )
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 async def test_config(p: PaperlessClient) -> None:

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -28,6 +28,7 @@ from .profile import DATA_PROFILE
 from .remote_version import DATA_REMOTE_VERSION
 from .saved_views import DATA_SAVED_VIEWS
 from .search import DATA_SEARCH
+from .search_autocomplete import DATA_SEARCH_AUTOCOMPLETE
 from .share_link_bundles import DATA_SHARE_LINK_BUNDLES
 from .share_links import DATA_SHARE_LINKS
 from .statistics import DATA_STATISTICS
@@ -84,6 +85,7 @@ __all__ = (
     "DATA_SAVED_VIEWS",
     "DATA_SCHEMA",
     "DATA_SEARCH",
+    "DATA_SEARCH_AUTOCOMPLETE",
     "DATA_SHARE_LINKS",
     "DATA_SHARE_LINK_BUNDLES",
     "DATA_STATISTICS",

--- a/tests/data/search_autocomplete.py
+++ b/tests/data/search_autocomplete.py
@@ -1,0 +1,3 @@
+"""Search autocomplete response fixture."""
+
+DATA_SEARCH_AUTOCOMPLETE = ["invoice", "invoices", "invoiced"]

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -41,6 +41,7 @@ from .data import (
     DATA_PROFILE,
     DATA_REMOTE_VERSION,
     DATA_SEARCH,
+    DATA_SEARCH_AUTOCOMPLETE,
     DATA_SHARE_LINK_BUNDLES,
     DATA_STATISTICS,
     DATA_STATUS,
@@ -529,13 +530,13 @@ class TestTrash:
 
 
 class TestSearch:
-    """Global search service: query and db_only flag."""
+    """Global search service: query, db_only flag and autocomplete."""
 
     async def test_call(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
         """search('query') returns a SearchResult with documents."""
         httpx_mock.add_response(
             method="GET",
-            url=re.compile(r"^" + f"{PAPERLESS_TEST_URL}{EndpointPath.SEARCH}" + r".*$"),
+            url=re.compile(r"^" + f"{PAPERLESS_TEST_URL}{EndpointPath.SEARCH}" + r"\?.*$"),
             status_code=200,
             json=DATA_SEARCH,
         )
@@ -555,7 +556,7 @@ class TestSearch:
         """search('query', db_only=True) passes db_only param and returns SearchResult."""
         httpx_mock.add_response(
             method="GET",
-            url=re.compile(r"^" + f"{PAPERLESS_TEST_URL}{EndpointPath.SEARCH}" + r".*db_only.*$"),
+            url=re.compile(r"^" + f"{PAPERLESS_TEST_URL}{EndpointPath.SEARCH}" + r"\?.*db_only.*$"),
             status_code=200,
             json=DATA_SEARCH,
         )
@@ -573,7 +574,7 @@ class TestSearch:
         """search(SearchQuery(...)) converts the builder to a string automatically."""
         httpx_mock.add_response(
             method="GET",
-            url=re.compile(r"^" + f"{PAPERLESS_TEST_URL}{EndpointPath.SEARCH}" + r".*$"),
+            url=re.compile(r"^" + f"{PAPERLESS_TEST_URL}{EndpointPath.SEARCH}" + r"\?.*$"),
             status_code=200,
             json=DATA_SEARCH,
         )
@@ -583,6 +584,42 @@ class TestSearch:
         assert result.total == DATA_SEARCH["total"]
 
         assert httpx_mock.get_requests()[-1].url.params["query"] == str(q)
+
+    async def test_autocomplete(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
+        """autocomplete() returns the bare term list and omits limit when unset."""
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(
+                r"^" + f"{PAPERLESS_TEST_URL}{EndpointPath.SEARCH_AUTOCOMPLETE}" + r"\?.*$"
+            ),
+            status_code=200,
+            json=DATA_SEARCH_AUTOCOMPLETE,
+        )
+        result = await paperless.search.autocomplete("inv")
+        assert result == DATA_SEARCH_AUTOCOMPLETE
+
+        params = httpx_mock.get_requests()[-1].url.params
+        assert params["term"] == "inv"
+        assert "limit" not in params
+
+    async def test_autocomplete_with_limit(
+        self, httpx_mock: HTTPXMock, paperless: PaperlessClient
+    ) -> None:
+        """autocomplete(term, limit) forwards the limit query parameter."""
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(
+                r"^" + f"{PAPERLESS_TEST_URL}{EndpointPath.SEARCH_AUTOCOMPLETE}" + r"\?.*limit.*$"
+            ),
+            status_code=200,
+            json=DATA_SEARCH_AUTOCOMPLETE[:1],
+        )
+        result = await paperless.search.autocomplete("inv", 1)
+        assert result == DATA_SEARCH_AUTOCOMPLETE[:1]
+
+        params = httpx_mock.get_requests()[-1].url.params
+        assert params["term"] == "inv"
+        assert params["limit"] == "1"
 
 
 class TestBulkEditObjects:
@@ -650,7 +687,7 @@ class TestBulkEditObjects:
 
 
 class TestDocumentsBulkEdit:
-    """DocumentBulkEditService: all 14 bulk operations."""
+    """DocumentBulkEditService: all 16 bulk operations."""
 
     async def test_set_correspondent(
         self, httpx_mock: HTTPXMock, paperless: PaperlessClient
@@ -899,6 +936,96 @@ class TestDocumentsBulkEdit:
         )
         with pytest.raises(BulkEditError):
             await paperless.documents.bulk_edit.modify_tags([1], add_tags=[3], remove_tags=[])
+
+    async def test_split(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
+        """split() translates page groups into edit_pdf doc indices."""
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{PAPERLESS_TEST_URL}{EndpointPath.DOCUMENTS_EDIT_PDF}",
+            status_code=200,
+            json=DATA_DOCUMENTS_BULK_EDIT,
+        )
+        await paperless.documents.bulk_edit.split(42, [[1, 2], [3]], delete_originals=True)
+        body = json.loads(httpx_mock.get_requests()[-1].content)
+        assert body["documents"] == [42]
+        assert body["operations"] == [
+            {"page": 1, "doc": 0},
+            {"page": 2, "doc": 0},
+            {"page": 3, "doc": 1},
+        ]
+        assert body["delete_original"] is True
+        assert body["update_document"] is False
+        assert body["source_mode"] == "latest_version"
+
+    @pytest.mark.parametrize("pages", [[], [[1], []]])
+    async def test_split_rejects_empty_groups(
+        self, paperless: PaperlessClient, pages: list[list[int]]
+    ) -> None:
+        """split() rejects an empty group list and empty groups before any request."""
+        with pytest.raises(ValueError, match="group"):
+            await paperless.documents.bulk_edit.split(42, pages)
+
+    async def test_delete_pages(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
+        """delete_pages() looks up the page count, then keeps the complement."""
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{PAPERLESS_TEST_URL}{EndpointPath.DOCUMENTS_SINGLE}".format(pk=42),
+            status_code=200,
+            json={"id": 42, "page_count": 5},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{PAPERLESS_TEST_URL}{EndpointPath.DOCUMENTS_EDIT_PDF}",
+            status_code=200,
+            json=DATA_DOCUMENTS_BULK_EDIT,
+        )
+        await paperless.documents.bulk_edit.delete_pages(42, [2, 4])
+
+        assert httpx_mock.get_requests()[-2].method == "GET"
+        body = json.loads(httpx_mock.get_requests()[-1].content)
+        assert body["documents"] == [42]
+        assert body["operations"] == [{"page": 1}, {"page": 3}, {"page": 5}]
+        assert body["update_document"] is True
+        assert body["delete_original"] is False
+
+    async def test_delete_pages_with_page_count(
+        self, httpx_mock: HTTPXMock, paperless: PaperlessClient
+    ) -> None:
+        """delete_pages(page_count=...) skips the document lookup."""
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{PAPERLESS_TEST_URL}{EndpointPath.DOCUMENTS_EDIT_PDF}",
+            status_code=200,
+            json=DATA_DOCUMENTS_BULK_EDIT,
+        )
+        await paperless.documents.bulk_edit.delete_pages(42, [1], page_count=3)
+
+        # schema probe + the edit_pdf POST — no document round-trip
+        assert len(httpx_mock.get_requests()) == 2
+        body = json.loads(httpx_mock.get_requests()[-1].content)
+        assert body["operations"] == [{"page": 2}, {"page": 3}]
+
+    async def test_delete_pages_without_page_count_raises(
+        self, httpx_mock: HTTPXMock, paperless: PaperlessClient
+    ) -> None:
+        """A document record without page_count cannot be edited without an explicit count."""
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{PAPERLESS_TEST_URL}{EndpointPath.DOCUMENTS_SINGLE}".format(pk=42),
+            status_code=200,
+            json={"id": 42, "page_count": None},
+        )
+        with pytest.raises(ValueError, match="no page count"):
+            await paperless.documents.bulk_edit.delete_pages(42, [1])
+
+    async def test_delete_pages_validates_pages(self, paperless: PaperlessClient) -> None:
+        """delete_pages() rejects empty, out-of-range and all-pages input locally."""
+        with pytest.raises(ValueError, match="at least one page to remove"):
+            await paperless.documents.bulk_edit.delete_pages(42, [], page_count=3)
+        with pytest.raises(ValueError, match="out of range"):
+            await paperless.documents.bulk_edit.delete_pages(42, [0, 4], page_count=3)
+        with pytest.raises(ValueError, match="keep at least one page"):
+            await paperless.documents.bulk_edit.delete_pages(42, [1, 2, 3], page_count=3)
 
 
 class TestShareLinkBundleRebuild:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -9,7 +9,13 @@ from pytest_httpx import HTTPXMock
 from pypaperless import PaperlessClient
 from pypaperless.builders import SearchQuery
 from pypaperless.const import EndpointPath
-from pypaperless.exceptions import BulkEditError, NotFoundError, TaskNotFoundError
+from pypaperless.exceptions import (
+    BulkEditError,
+    BulkEditPagesError,
+    NotFoundError,
+    PaperlessError,
+    TaskNotFoundError,
+)
 from pypaperless.models import (
     Config,
     Document,
@@ -962,7 +968,7 @@ class TestDocumentsBulkEdit:
         self, paperless: PaperlessClient, pages: list[list[int]]
     ) -> None:
         """split() rejects an empty group list and empty groups before any request."""
-        with pytest.raises(ValueError, match="group"):
+        with pytest.raises(BulkEditPagesError, match="group"):
             await paperless.documents.bulk_edit.split(42, pages)
 
     async def test_delete_pages(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
@@ -1015,17 +1021,22 @@ class TestDocumentsBulkEdit:
             status_code=200,
             json={"id": 42, "page_count": None},
         )
-        with pytest.raises(ValueError, match="no page count"):
+        with pytest.raises(BulkEditPagesError, match="no page count"):
             await paperless.documents.bulk_edit.delete_pages(42, [1])
 
     async def test_delete_pages_validates_pages(self, paperless: PaperlessClient) -> None:
         """delete_pages() rejects empty, out-of-range and all-pages input locally."""
-        with pytest.raises(ValueError, match="at least one page to remove"):
+        with pytest.raises(BulkEditPagesError, match="at least one page to remove"):
             await paperless.documents.bulk_edit.delete_pages(42, [], page_count=3)
-        with pytest.raises(ValueError, match="out of range"):
+        with pytest.raises(BulkEditPagesError, match="out of range"):
             await paperless.documents.bulk_edit.delete_pages(42, [0, 4], page_count=3)
-        with pytest.raises(ValueError, match="keep at least one page"):
+        with pytest.raises(BulkEditPagesError, match="keep at least one page"):
             await paperless.documents.bulk_edit.delete_pages(42, [1, 2, 3], page_count=3)
+
+    def test_bulk_edit_pages_error_bases(self) -> None:
+        """Both bases are load-bearing: `except PaperlessError` and `except ValueError` catch it."""
+        assert issubclass(BulkEditPagesError, PaperlessError)
+        assert issubclass(BulkEditPagesError, ValueError)
 
 
 class TestShareLinkBundleRebuild:


### PR DESCRIPTION
## Proposed change

Adds three methods to the public API, one exception, and corrects one type alias.

**`SearchService.autocomplete(term, limit=None)`** wraps `/api/search/autocomplete/`, the typeahead endpoint behind the Paperless-ngx search bar. It returns a bare `list[str]`; `limit` is omitted from the request when left at `None`, so the server default (10) applies.

```python
terms = await paperless.search.autocomplete("inv")
# ['invoice', 'invoices', 'invoiced']
```

**`DocumentBulkEditService.split()` and `.delete_pages()`** are implemented as wrappers around the existing `edit_pdf()`, not as the `split` / `delete_pages` bulk_edit methods. Upstream deprecated those in API v10: `BulkEditSerializer` maps both to `/api/documents/edit_pdf/` via `MOVED_DOCUMENT_ACTION_ENDPOINTS`, the view logs a deprecation warning per call, and — unlike `merge`, `rotate` and `edit_pdf` — neither gets an individual endpoint of its own. The upstream comment reads `split, delete_pages can be removed entirely`. `edit_pdf` already expresses both operations anyway: `doc` is the output-document index (= split), and pages omitted from `operations` are discarded (= delete pages).

```python
# two new documents: pages 1-2 and page 3
await paperless.documents.bulk_edit.split(42, [[1, 2], [3]])

# drop pages 2 and 4, creating a new version of document 42
await paperless.documents.bulk_edit.delete_pages(42, [2, 4])
```

Both take a single `document: int` rather than a list, because the server rejects more than one document for either operation (`"Split method only supports one document"`) — the same constraint `edit_pdf()` already models. And since `edit_pdf` keeps the pages it is handed rather than removing them, `delete_pages()` computes the complement and therefore needs the page count. It is looked up from the document record unless `page_count=` is passed, which also covers the two cases where the record is not the right source: documents that carry no page count (not a PDF, or not processed yet), and a `source_mode` selecting a file with a different number of pages.

**`BulkEditPagesError`** is raised by both for input that cannot produce a valid PDF: no page groups, an empty group, no pages to remove, page numbers outside the document, or removing every page. Without those guards the server runs `max()` over an empty operations list, and `delete_pages(42, [99])` on a 5-page document would silently create a new version identical to the old one.

It subclasses `DocumentError` **and** `ValueError`. The `ValueError` base is the ergonomic one; the `DocumentError` base is the load-bearing one, because it keeps the error inside the documented `PaperlessError` hierarchy. Consumers that dispatch on exception type — an MCP server translating library errors into structured tool results, say — otherwise have nothing to match on and are forced into a blanket `except ValueError`, which would also swallow unrelated failures from anywhere in the stack. A test pins both bases.

One more behavioural note on `split()`, documented in the docstring and in `docs/concepts/documents.md`: results inherit the source metadata unchanged, so the legacy endpoint's `(split 1)`, `(split 2)`, … title suffix is not reproduced.

**`SourceMode` correction.** The literal was `Literal["latest_version", "original"]`, but upstream is `Literal["latest_version", "explicit_selection"]`, and `SourceModeValidationMixin.validate_source_mode` rejects anything outside `SourceModeChoices` — so `source_mode="original"` has always come back as HTTP 400. `docs/concepts/documents.md` showed exactly that call as its example. Nothing that previously worked stops working; only what a type checker accepts changes. Affects `rotate()`, `merge()`, `edit_pdf()`, `remove_password()` and the two new methods.

Finally, `/api/search/autocomplete/` moves from `INTENTIONALLY_SKIPPED_PATHS` to `KNOWN_UTILITY_PATHS` in `script/pngx_audit_coverage.py`, now that it is implemented rather than deliberately out of scope.

### Known limitation: `delete_pages()` is not atomic

`edit_pdf` takes the pages to *keep*, so the complement is computed client-side from a page count read in an earlier request. If the document gains a version between the lookup and the edit, the wrong pages survive. A shorter new file is rejected by the server as out of bounds, but a longer one silently loses its extra pages. Passing `page_count=` does not close the window — it skips the lookup and moves the staleness to the caller's own read.

The deprecated native `delete_pages` bulk method did not have this window: it removed pages by index from the file it opened server-side, so it never needed a page count. That is the cost of not depending on a method upstream intends to remove, and it is documented rather than hidden.

Worth noting what this does *not* cost: no bump to the supported server floor. `edit_pdf` is much younger than `split`/`delete_pages` — paperless-ngx 2.18.0 vs 2.9.0, with the dedicated endpoint arriving only in 3.0 — but pypaperless already required Paperless-ngx >= 3.0, `edit_pdf()` already shipped on `main`, and `delete`, `reprocess`, `rotate`, `merge` and `remove_password` were already on v10 dedicated endpoints.

### Why now

This was initiated by my own [tb1337/paperless-mcp](https://github.com/tb1337/paperless-mcp) project, which needs search autocompletion and page-level document operations. Landing them here first keeps the MCP server a thin layer over pypaperless instead of hand-rolling raw API calls against endpoints the library already knows about.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Code quality, refactor or performance (no functional change)
- [ ] Documentation
- [ ] CI, tooling or dependency update

## Breaking change

Not applicable. The `SourceMode` change narrows a public type alias, but `"original"` was never a value the server accepted, so no working code changes behaviour — only static type checking gets stricter. `BulkEditPagesError` is purely additive and keeps `ValueError` as a base.

## Related issues

No linked issue. Driven by [tb1337/paperless-mcp](https://github.com/tb1337/paperless-mcp) — see "Why now" above.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] AI and agentic coding tools are very welcome here. If I used one, I have read and reviewed its entire output myself and take responsibility for it.
- [x] `uv run pytest -x -q` passes locally and coverage stays at 95 % or above.
- [x] `prek run --all-files` passes (ruff, mypy, codespell, yamllint).
- [x] Tests have been added or updated for the changed behavior.
- [x] (OPTIONAL) The docs in `docs/` have been updated if the public API changed.
- [x] (OPTIONAL) `uv run python script/pngx_smoketest.py` passed against a live instance, or the change cannot affect live API interaction.